### PR TITLE
Fix return type in function _ensure_secret

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,27 +1,27 @@
 {
     "item_git_deploy": {
-        "checksum": "1b8e95c1539edb023824ebc9b1e63315b0099a0a", 
-        "desc": "Item type for managing git checkouts", 
+        "checksum": "1b8e95c1539edb023824ebc9b1e63315b0099a0a",
+        "desc": "Item type for managing git checkouts",
         "version": 5
-    }, 
+    },
     "itermstats": {
-        "checksum": "5362cba892b1975a528eaa63b135b39f389f3639", 
-        "desc": "Pretty stats using iTerm2 PNG support and pygal", 
+        "checksum": "5362cba892b1975a528eaa63b135b39f389f3639",
+        "desc": "Pretty stats using iTerm2 PNG support and pygal",
         "version": 4
-    }, 
+    },
     "notify_hipchat": {
-        "checksum": "fbb246a863fc911532815f199cd080581881f306", 
-        "desc": "Automatically send notifications to HipChat rooms with bw apply", 
+        "checksum": "fbb246a863fc911532815f199cd080581881f306",
+        "desc": "Automatically send notifications to HipChat rooms with bw apply",
         "version": 9
-    }, 
+    },
     "notify_slack": {
-        "checksum": "bdf6da504d1d688bb1d9eb0de34b85afbc504a12", 
-        "desc": "Automatically send notifications to Slack rooms with bw apply", 
+        "checksum": "bdf6da504d1d688bb1d9eb0de34b85afbc504a12",
+        "desc": "Automatically send notifications to Slack rooms with bw apply",
         "version": 2
-    }, 
+    },
     "pwget": {
-        "checksum": "73933b3b5c5663b609e8416f3fd684e481758ef9", 
-        "desc": "Derive passwords in your repo from a shared secret", 
-        "version": 9
+        "checksum": "59583c467c2558dd60492c2e82250453c853bd9d",
+        "desc": "Derive passwords in your repo from a shared secret",
+        "version": 10
     }
 }

--- a/pwget/libs/pw.py
+++ b/pwget/libs/pw.py
@@ -30,7 +30,7 @@ def _ensure_secret(path):
                     "-s",
                     "bundlewrap",
                     "-w",
-                ]).strip()
+                ]).strip().decode('utf-8')
             except CalledProcessError:
                 raise IOError(
                     "Unable to read pwget secret from {path} or Mac OS Keychain. "

--- a/pwget/manifest.json
+++ b/pwget/manifest.json
@@ -4,5 +4,5 @@
 	"provides": [
 		"libs/pw.py"
 	],
-	"version": 9
+	"version": 10
 }


### PR DESCRIPTION
Hi Thorsten,

I got an issue while using pw in MacOS (python 3.5). 

The error: 
`File "/anywhere/bundlewrap/libs/pw.py", line 160, in get
    h = hmac.new(secret.encode('utf-8'), digestmod=hashlib.sha512)
AttributeError: 'bytes' object has no attribute 'encode'`

This is because of the subprocess.check_output [here](https://github.com/bundlewrap/plugins/blob/master/pwget/libs/pw.py#L25). [subprocess.check_output](https://docs.python.org/3/library/subprocess.html#subprocess.check_output) returns an encoded bytes array, so the encode in line 160 will fail and raise an exception.
