### PR TITLE
item_download: Fix types of attribute defaults

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,8 +1,8 @@
 {
     "item_download": {
-        "checksum": "367aa0f86cb68d42d77f340da74d803368213f90",
+        "checksum": "084d801a07e7d5a888a3859ecbf6e64cd7e03629",
         "desc": "Download a file from a webserver and verifies its Hash",
-        "version": 3
+        "version": 4
     },
     "item_git_deploy": {
         "checksum": "63ee7962325d88ce8bc056d6bb3fde9ab7104074",

--- a/item_download/items/download.py
+++ b/item_download/items/download.py
@@ -18,8 +18,8 @@ class Download(Item):
         "pkg_zypper:",
     ]
     ITEM_ATTRIBUTES = {
-        'url': {},
-        'sha256': {},
+        'url': "",
+        'sha256': "",
         'verifySSL': True,
     }
     ITEM_TYPE_NAME = "download"
@@ -54,13 +54,13 @@ class Download(Item):
             self.node.run("curl -L {verify}-s -o {file} -- {url}".format(
                 verify="" if self.attributes.get('verifySSL', True) else "-k ",
                 file=quote(self.name),
-                url=quote(self.attributes.get('url'))
+                url=quote(self.attributes['url'])
             ))
 
             # check hash
             sha256 = self.__hash_remote_file(self.name)
 
-            if sha256 != self.attributes.get('sha256'):
+            if sha256 != self.attributes['sha256']:
                 # unlink file
                 self.node.run("rm -rf -- {}".format(quote(self.name)))
 
@@ -70,7 +70,7 @@ class Download(Item):
         """This is how the world should be"""
         cdict = {
             'type': 'download',
-            'sha256': self.attributes.get('sha256'),
+            'sha256': self.attributes['sha256'],
         }
 
         return cdict
@@ -90,7 +90,7 @@ class Download(Item):
 
     @classmethod
     def validate_attributes(cls, bundle, item_id, attributes):
-        if not attributes.get('sha256', None):
+        if 'sha256' not in attributes:
             raise BundleError(_(
                 "at least one hash must be set on {item} in bundle '{bundle}'"
             ).format(
@@ -98,7 +98,7 @@ class Download(Item):
                 item=item_id,
             ))
 
-        if not attributes.get('url', None):
+        if 'url' not in attributes:
             raise BundleError(_(
                 "you need to specify the url on {item} in bundle '{bundle}'"
             ).format(

--- a/item_download/manifest.json
+++ b/item_download/manifest.json
@@ -4,5 +4,5 @@
 	"provides": [
 		"items/download.py"
 	],
-	"version": 3
+	"version": 4
 }


### PR DESCRIPTION
With bw 3.7, the type of an attribute's default matters a great deal.
You can't just use random stuff that evaluates to a boolean "False"
anymore (and IMHO that shouldn't have been done in the first place).

Also unify/clarify the ".get()" calls. There is no need for them, since
we validate attributes in "validate_attributes()". Nor is there a need
to introduce new types (i.e., "None") via ".get()".